### PR TITLE
Unix Casing in Path

### DIFF
--- a/webpack/webpack.common.js
+++ b/webpack/webpack.common.js
@@ -20,7 +20,7 @@ module.exports = {
             'ContentScript',
             'index.ts',
         ),
-        popup: path.join(srcPath, 'Popup', 'index.tsx'),
+        popup: path.join(srcPath, 'popup', 'index.tsx'),
     },
     output: {
         path: path.join(rootPath, 'dist'),


### PR DESCRIPTION


## Description
fixed casing issue in webpack.common.js that prevented unix and unix-like systems from building


Fixes # (issue)
Popup changed to popup in webpack.common.js

## Type of change

Please delete options that are not relevant.

-   [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)


## How Has This Been Tested?

tested build on Fedora Linux
